### PR TITLE
Steam (almost) Works

### DIFF
--- a/ChatBot/ChatBot.csproj
+++ b/ChatBot/ChatBot.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="NAudio" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="SteamKit2" Version="2.4.1" />
     <PackageReference Include="System.Windows.Extensions" Version="6.0.0" />
     <PackageReference Include="TwitchLib" Version="3.2.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />

--- a/ChatBot/Program.cs
+++ b/ChatBot/Program.cs
@@ -1,14 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading;
+using ChatBot.SteamWorks;
 
 namespace ChatBot
 {
     class Program
     {
+        private static void ReceivedLobbies(IEnumerable<ThunderDomeLobby> lobbies)
+        {
+            int count = lobbies.Count();
+            for (int n = 0; n < count; ++n)
+            {
+                var l = lobbies.ElementAt(n);
+                Console.Write($" Lobby {n}/{count} ({l.Id % 1000}): {l.NumPlayers}/{l.MaxMembers}, {l.AverageElo} skill");
+            }
+        }
+
         public static void Main()
         {
-            Console.ReadLine();
+            // Monitor thunderdome lobbies. Info will go to the console.
+            using (var cts = new CancellationTokenSource())
+            using (var tdwatcher = new LobbyWatcher(ReceivedLobbies,
+                l => l.AverageElo >= 100 && l.NumPlayers >= 1 && l.NumPlayers < l.MaxMembers && l.Status == ELobbyState.Queueing))
+            {
+                tdwatcher.BeginPolling(cts.Token);
+
+                Console.WriteLine("Press 'Q' to end program ..." + Environment.NewLine);
+                while (Console.ReadKey(true).Key != ConsoleKey.Q && tdwatcher.PollingTask.Status == System.Threading.Tasks.TaskStatus.Running)
+                {
+                    Thread.Sleep(200);
+                }
+                cts.Cancel();
+
+                if (!tdwatcher.PollingTask.Wait(10 * 1000))
+                {
+                    Console.WriteLine("took longer than 10 seconds to shutdown. naughty boi.");
+                }
+            }
         }
     }
 }

--- a/ChatBot/SteamWorks/LobbyWatcher.cs
+++ b/ChatBot/SteamWorks/LobbyWatcher.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SteamKit2;
+
+#nullable enable
+
+namespace ChatBot.SteamWorks
+{
+    public enum WatcherState
+    {
+        Invalid = 0,
+
+        Connecting,
+        Connected,
+        LoggingIn,
+        Received2FARequest,
+        Submitting2FAResponse,
+        LoggedIn,
+        Searching,
+        Idle,
+        Disconnecting,
+
+        Completed,
+        Disconnected,
+        LoginFailed,
+        Errored,
+        Disposed,
+    }
+
+    // Short-lived state if we get disconnected due to 2FA.
+    public class Steam2FAData
+    {
+        public string? AppCode { get; set; } = null;
+        public string? EmailCode { get; set; } = null;
+    }
+
+    public class LobbyWatcher : IDisposable
+    {
+        public Task? PollingTask { get; private set; } = null;
+
+        public WatcherState Status { get; private set; } = WatcherState.Invalid;
+
+
+        private readonly Steam2FAData _twoFAdata;
+        private readonly List<IDisposable> _cbHandles;
+        private readonly CallbackManager _cbManager;
+        private readonly Action<IEnumerable<ThunderDomeLobby>> _matchAction;
+        private readonly Func<ThunderDomeLobby, bool> _matchPredicate;
+        private readonly SteamClient _steamClient;
+
+        private uint? _cellId;
+
+        private SteamMatchmaking MatcherImpl => _steamClient.GetHandler<SteamMatchmaking>()
+            ?? throw new InvalidCastException("Failed to retrieve SteamMatchmaking interface");
+
+        private SteamUser UserImpl => _steamClient.GetHandler<SteamUser>()
+            ?? throw new InvalidCastException("Failed to retrieve SteamUser interface");
+
+
+        public LobbyWatcher(Action<IEnumerable<ThunderDomeLobby>>? matchAction = null, Func<ThunderDomeLobby, bool>? matchPredicate = null)
+        {
+            if (matchAction is null)
+            {
+                _matchAction = lobbies =>
+                {
+                    StringBuilder sb = new StringBuilder();
+                    foreach (var lobby in lobbies)
+                    {
+                        string state = lobby.NumPlayers >= 10 ? "nearly full" : lobby.NumPlayers >= 9 ? "filling up" : "seeding";
+                        string branch = lobby.Branch == "public" ? string.Empty : $" (branch {lobby.Branch.ToUpper()})";
+                        sb.Append($"{lobby.LobbyType} ThunderDome Lobby {lobby.Id % 1000}{branch} is {state} ({lobby.NumPlayers}/{lobby.MaxMembers}) with {lobby.AverageElo} elo.");
+                    }
+                    Console.WriteLine(sb.ToString());
+                };
+            }
+            else
+            {
+                _matchAction = matchAction;
+            }
+
+            if (matchPredicate is null)
+            {
+                _matchPredicate = l =>
+                {
+                    return
+                        (l.LobbyType == ELobbyType.Public || l.LobbyType == ELobbyType.FriendsOnly) &&
+                        (l.Status == ELobbyState.Queueing) &&
+                        (l.NumPlayers >= 10 || l.NumPlayers >= 6 && l.AverageElo >= 2000);
+                };
+            }
+            else
+            {
+                _matchPredicate = matchPredicate;
+            }
+
+            _twoFAdata = new Steam2FAData();
+            _steamClient = new SteamClient(SteamConfiguration.Create(c =>
+            {
+                c.WithCellID(GetCellId())
+                 .WithMachineInfoProvider(SysInfoProvider.Instance)
+                 .WithServerListProvider(new SteamKit2.Discovery.FileStorageServerListProvider(ServerListFilePath))
+                 .WithUniverse(EUniverse.Public);
+            }));
+            _cbManager = new CallbackManager(_steamClient);
+            _cbHandles = new List<IDisposable>
+            {
+                _cbManager.Subscribe<SteamClient.ConnectedCallback>(Client_Connected),
+                _cbManager.Subscribe<SteamClient.DisconnectedCallback>(Client_Disconnected),
+                _cbManager.Subscribe<SteamUser.LoginKeyCallback>(User_RefreshUserAuth),
+                _cbManager.Subscribe<SteamUser.LoggedOnCallback>(User_LoggedIn),
+                _cbManager.Subscribe<SteamUser.LoggedOffCallback>(User_LoggedOut),
+                _cbManager.Subscribe<SteamUser.UpdateMachineAuthCallback>(User_RefreshMachineAuth),
+                _cbManager.Subscribe<SteamMatchmaking.GetLobbyListCallback>(MatchMaking_ReceivedLobbies)
+            };
+
+            if (!Directory.Exists(Path.Join(Config.fileSavePath, "steam")))
+            {
+                Directory.CreateDirectory(Path.Join(Config.fileSavePath, "steam"));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_steamClient.IsConnected)
+            {
+                _steamClient.Disconnect();
+                _cbManager.RunWaitAllCallbacks(TimeSpan.FromSeconds(5));
+            }
+
+            if (_cbHandles.Count > 0)
+            {
+                foreach (var cbHandle in _cbHandles)
+                {
+                    cbHandle.Dispose();
+                }
+                _cbHandles.Clear();
+            }
+
+            PollingTask?.Dispose();
+            PollingTask = null;
+        }
+
+        public void BeginPolling(CancellationToken? cancellationToken = null)
+        {
+            // no token provided, so bind to CTRL+C on the console to disconnect from steam.
+            if (cancellationToken is null)
+            {
+                var cts = new CancellationTokenSource();
+                Console.CancelKeyPress += (_, e) =>
+                {
+                    if (!cts.IsCancellationRequested)
+                    {
+                        cts.Cancel();
+                    }
+                    e.Cancel = _steamClient.IsConnected;
+                };
+                cancellationToken = cts.Token;
+            }
+
+            PollingTask = Task.Factory.StartNew(() =>
+            {
+                _steamClient.Connect();
+                Status = WatcherState.Connecting;
+
+                while (!cancellationToken.Value.IsCancellationRequested && Status >= WatcherState.Connecting && Status <= WatcherState.Disconnecting)
+                {
+                    _cbManager.RunWaitCallbacks(TimeSpan.FromMilliseconds(250));
+
+                    if (cancellationToken.Value.IsCancellationRequested)
+                    {
+                        _steamClient.Disconnect();
+                        Status = WatcherState.Disconnecting;
+                    }
+                }
+                Status = WatcherState.Completed;
+            });
+        }
+
+
+        void Client_Connected(SteamClient.ConnectedCallback cb)
+        {
+            Status = WatcherState.Connected;
+
+            // TODO: check out SteamUser.LogOnAnonymous, as we might able to do this without auth...
+            UserImpl.LogOn(new SteamUser.LogOnDetails
+            {
+                Username = Config.SteamUsername,
+
+                // TODO: these are really only needed during first authentication, but it seems
+                // silly to read the password from the console given the app's current design.
+                Password = Config.SteamPassword,
+
+                // 2fa tokens *will* be read from the console.
+                AuthCode = _twoFAdata.EmailCode,
+                TwoFactorCode = _twoFAdata.AppCode,
+
+                LoginKey = GetUserKey(),
+                ShouldRememberPassword = true,
+
+                SentryFileHash = GetMachineKey(),
+
+                // set this value non-null to not interfere with the actual Steam client that's likely also running on this computer.
+                LoginID = 6942069,
+            });
+            Status = WatcherState.LoggingIn;
+
+            _twoFAdata.AppCode = null;
+            _twoFAdata.EmailCode = null;
+        }
+
+        void Client_Disconnected(SteamClient.DisconnectedCallback cb)
+        {
+            // 2FA requests will knock us offline during the auth procedure, so just ignore it.
+            if (!(Status == WatcherState.Received2FARequest || Status == WatcherState.Submitting2FAResponse))
+            {
+                Status = WatcherState.Disconnected;
+                Console.WriteLine("Disconnected from Steam");
+            }
+        }
+
+        void User_LoggedIn(SteamUser.LoggedOnCallback cb)
+        {
+            if (cb.Result == EResult.AccountLoginDeniedNeedTwoFactor || cb.Result == EResult.AccountLogonDenied)
+            {
+                Status = WatcherState.Received2FARequest;
+
+                Console.Write($"Please enter the 2FA code from your {(cb.Result == EResult.AccountLoginDeniedNeedTwoFactor ? "authenticator app" : "email")}: ");
+
+                if (cb.Result == EResult.AccountLoginDeniedNeedTwoFactor)
+                {
+                    _twoFAdata.AppCode = Console.ReadLine();
+                }
+                else if (cb.Result == EResult.AccountLogonDenied)
+                {
+                    _twoFAdata.EmailCode = Console.ReadLine();
+                }
+
+                _cbManager.RunWaitCallbacks(TimeSpan.FromSeconds(2));
+                Thread.Sleep(2000);
+                _steamClient.Connect();
+
+                Status = WatcherState.Submitting2FAResponse;
+                _cbManager.RunWaitCallbacks();
+
+                return;
+            }
+            else if (cb.Result != EResult.OK)
+            {
+                Console.WriteLine($"Unable to login to Steam: {cb.Result} / {cb.ExtendedResult}.");
+                Status = WatcherState.LoginFailed;
+
+                return;
+            }
+
+            // If neither of the above applied, we're now logged in to steam.
+            Status = WatcherState.LoggedIn;
+            if (cb.CellID != _cellId)
+            {
+                _cellId = cb.CellID;
+                SetCellId(cb.CellID);
+            }
+
+            Task.Factory.StartNew(() =>
+            {
+                Thread.Sleep(10 * 1000);
+                MatcherImpl.GetLobbyList(Ns2AppId);
+                Status = WatcherState.Searching;
+            });
+        }
+
+        void User_LoggedOut(SteamUser.LoggedOffCallback cb)
+        {
+            _steamClient.Disconnect();
+
+            // Delete the client token. I don't actually invoke logging out anywhere, but this token's now entirely pointless.
+            if (File.Exists(UserKeyFilePath))
+            {
+                try
+                {
+                    File.Delete(UserKeyFilePath);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to delete Steam auth token file \"{UserKeyFileName}\": {ex.Message}");
+                }
+            }
+        }
+
+        async void User_RefreshUserAuth(SteamUser.LoginKeyCallback cb)
+        {
+            await File.WriteAllTextAsync(UserKeyFilePath, cb.LoginKey)
+                .ContinueWith((t) =>
+                {
+                    if (!t.IsFaulted && t.IsCompleted)
+                        UserImpl.AcceptNewLoginKey(cb);
+                });
+
+        }
+
+        async void User_RefreshMachineAuth(SteamUser.UpdateMachineAuthCallback cb)
+        {
+            bool err = false;
+            int fileSize = 0;
+            try
+            {
+                using (var fs = File.Open(MachineKeyFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+                {
+                    fs.Seek(cb.Offset, SeekOrigin.Begin);
+                    await fs.WriteAsync(cb.Data, 0, cb.Data.Length);
+                    fileSize = (int)fs.Length;
+                }
+            }
+            catch
+            {
+                err = true;
+            }
+
+            UserImpl.SendMachineAuthResponse(new SteamUser.MachineAuthDetails
+            {
+                JobID = cb.JobID,
+                FileName = cb.FileName,
+                FileSize = fileSize,
+                Offset = cb.Offset,
+                Result = err ? EResult.UnexpectedError : EResult.OK,
+                LastError = 0,
+                OneTimePassword = cb.OneTimePassword,
+                SentryFileHash = GetMachineKey(),
+            });
+        }
+
+        void MatchMaking_ReceivedLobbies(SteamMatchmaking.GetLobbyListCallback cb)
+        {
+            var lobbies = cb.Lobbies
+                .Select(l => ThunderDomeLobby.FromSteamKit(l))
+                .Where(l => _matchPredicate(l))
+                .ToList();
+
+            if (lobbies.Any())
+            {
+                _matchAction(lobbies);
+            }
+        }
+
+
+
+
+        private static uint GetCellId()
+        {
+            try
+            {
+                if (File.Exists(CellIdFilePath) && uint.TryParse(File.ReadAllText(CellIdFilePath), out var cellId))
+                {
+                    return cellId;
+                }
+            }
+            catch
+            {
+            }
+            return 0;
+        }
+
+        private static void SetCellId(uint value)
+        {
+            File.WriteAllText(CellIdFilePath, value.ToString());
+        }
+
+        private static byte[]? GetMachineKey()
+        {
+            try
+            {
+                if (File.Exists(MachineKeyFilePath))
+                {
+                    using var fs = File.Open(MachineKeyFilePath, FileMode.Open, FileAccess.Read);
+                    using var sha = SHA1.Create();
+                    return sha.ComputeHash(fs);
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+        private static string? GetUserKey()
+        {
+            try
+            {
+                if (File.Exists(UserKeyFilePath))
+                {
+                    return File.ReadAllText(UserKeyFilePath);
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+
+        // Steam Works wants to save a lot of stuff to disk. Server lists, auth tokens, etc.
+        // All of it is essentially junk, so keep it confined to %LocalAppData%\PeerBot\steam\
+        private static string GetConfigFilePath(string fileName)
+        {
+            // TODO: if desired: string datadir = Config.fileSavePath;
+            string datadir = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PeerBot");
+
+            if (!Directory.Exists(datadir))
+            {
+                Directory.CreateDirectory(datadir);
+            }
+
+            datadir = Path.Combine(datadir, "steam");
+            if (!Directory.Exists(datadir))
+            {
+                Directory.CreateDirectory(datadir);
+            }
+
+            return Path.Join(datadir, fileName);
+        }
+
+
+        private const int Ns2AppId = 4920;
+
+        // Contains a number that represents your geographic region to steam.
+        private const string CellIdFileName = "cellid.txt";
+        private static string CellIdFilePath { get; } = GetConfigFilePath(CellIdFileName);
+
+        // Contains machine auth token. *** File is controlled entirely by Valve through callbacks ***
+        // is hashed and sent to attest during user authentication.
+        private const string MachineKeyFileName = "machine.bin";
+        private static string MachineKeyFilePath { get; } = GetConfigFilePath(MachineKeyFileName);
+
+        // Contains user's auth token.
+        private const string UserKeyFileName = "userid.txt";
+        private static string UserKeyFilePath { get; } = GetConfigFilePath(UserKeyFileName);
+
+        // Contains information about steam servers.
+        private const string ServerListFileName = "servers.bin";
+        private static string ServerListFilePath { get; } = GetConfigFilePath(ServerListFileName);
+    }
+}

--- a/ChatBot/SteamWorks/SysInfoProvider.cs
+++ b/ChatBot/SteamWorks/SysInfoProvider.cs
@@ -1,0 +1,105 @@
+using SteamKit2;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Security.Cryptography;
+using System.Text;
+
+#nullable enable
+
+namespace ChatBot.SteamWorks
+{
+    // Singleton. Provides hashed information about the device for auth attestation purposes.
+    public class SysInfoProvider : IMachineInfoProvider
+    {
+        public static IMachineInfoProvider Instance
+        {
+            get
+            {
+                s_instance ??= new SysInfoProvider();
+                return s_instance;
+            }
+        }
+
+        private static SysInfoProvider? s_instance = null;
+
+        private SysInfoProvider()
+        {
+            var di = DriveInfo.GetDrives().FirstOrDefault(d => d.DriveType == DriveType.Fixed && d.Name.ToLower() == @"c:\");
+            _DiskId = Hash(string.Join('-', di?.VolumeLabel ?? "defaultVolume", di?.TotalSize.ToString() ?? "defaultSize", di?.DriveFormat ?? "defaultFormat"));
+
+            _MacAddress = Hash(GetNetworkAdapters()
+                .FirstOrDefault()?
+                .GetPhysicalAddress()
+                .GetAddressBytes());
+
+            _MachineGuid = Hash(string.Join(".",
+                string.IsNullOrEmpty(Environment.UserDomainName.Trim()) ? "UnknownDomain" : Environment.UserDomainName,
+                string.IsNullOrEmpty(Environment.MachineName.Trim()) ? "UnknownMachineName" : Environment.MachineName,
+                string.IsNullOrEmpty(Environment.UserName.Trim()) ? "UnknownUserName" : Environment.UserName));
+        }
+
+
+        byte[] IMachineInfoProvider.GetDiskId() => _DiskId;
+        private readonly byte[] _DiskId;
+
+        byte[] IMachineInfoProvider.GetMacAddress() => _MacAddress;
+        private readonly byte[] _MacAddress;
+
+        byte[] IMachineInfoProvider.GetMachineGuid() => _MachineGuid;
+        private readonly byte[] _MachineGuid;
+
+
+        private static byte[] Hash(byte[]? value)
+        {
+            const string salt = "-- Hello there. I hope you are doing well. This text is just hashing salt. Just salt.";
+
+            using var sha = SHA1.Create();
+            var b64val = value is null || value.Length < 1 ? "null null null" : Convert.ToBase64String(value);
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(b64val + salt));
+            if (value != null && value.Length > 8 && value.Length <= hash.Length)
+            {
+                return hash.Take(value.Length).ToArray();
+            }
+            else
+            {
+                return hash;
+            }
+        }
+
+        private static byte[] Hash(string? value)
+        {
+            return Hash(Encoding.UTF8.GetBytes(value ?? string.Empty));
+        }
+
+        private static IEnumerable<NetworkInterface> GetNetworkAdapters()
+        {
+            // if you've got a DSL or some other wonky connection as the main one to your computer, adjust this boomer.
+            // if you're switching primary connection methods a lot (wifi, ethernet, VPNs, tunnels, etc.), adjust this zoomer.
+            var types = new List<NetworkInterfaceType>
+                {
+                    NetworkInterfaceType.Ethernet,
+                    NetworkInterfaceType.Ethernet3Megabit,
+                    NetworkInterfaceType.FastEthernetT,
+                    NetworkInterfaceType.FastEthernetFx,
+                    NetworkInterfaceType.Wireless80211,
+                    NetworkInterfaceType.GigabitEthernet,
+                    NetworkInterfaceType.Tunnel,
+                    NetworkInterfaceType.Wman,
+                    NetworkInterfaceType.Wwanpp,
+                    NetworkInterfaceType.Wwanpp2
+                };
+
+            var nics = NetworkInterface.GetAllNetworkInterfaces();
+            var best = nics.Where(n
+                    => n.OperationalStatus == OperationalStatus.Up
+                    && !n.IsReceiveOnly
+                    && types.Contains(n.NetworkInterfaceType))
+                .OrderByDescending(n => n.Speed);
+
+            return best;
+        }
+    }
+}

--- a/ChatBot/SteamWorks/ThunderDomeLobby.cs
+++ b/ChatBot/SteamWorks/ThunderDomeLobby.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using SteamKit2;
+
+#nullable enable
+
+namespace ChatBot.SteamWorks
+{
+    public enum ELobbyState
+    {
+        Unknown = 0,
+        Queueing = 1,
+        Unknown2 = 2, // Choosing commanders?
+        Unknown3 = 3, // Choosing maps?
+        Unknown4 = 4, // Choosing life forms (300s spinup)
+        Unknown5 = 5, // Playing first round?
+        Unknown6 = 6, // Playing second round?
+        Completed = 7,
+    }
+
+    /// <summary>A data class containing information about a ThunderDome lobby.</summary>
+    public class ThunderDomeLobby
+        : IComparable<ThunderDomeLobby>
+        , IEquatable<ThunderDomeLobby>
+    {
+        public ThunderDomeLobby()
+        {
+        }
+
+
+        /// <summary>Gets or sets the median skill of the lobby.</summary>
+        public int AverageElo { get; set; } = 0;
+
+        /// <summary>Gets or sets the branch of the game the lobby is operating on.</summary>
+        /// <remarks>At least "public" and "beta" are valid options, but there's presumably others.</remarks>
+        public string Branch { get; set; } = "public";
+
+        /// <summary>Gets or sets the build number of the game the lobby is operating on.</summary>
+        /// <remarks>This is currently at <c>341</c> at the time of this writing.</remarks>
+        public int Build { get; set; } = 0;
+
+        /// <summary>Gets or sets the straight-line distance to the median lobby location.</summary>
+        /// <remarks>The meaning of this value has not been fully fleshed out. It is quite likely that
+        /// this value is just "miles from your location to the average player location", and the
+        /// closest datacenter to this location will be used to spin up the game server.</remarks>
+        public float Distance { get; set; } = 0f; // TODO: Is this miles? Kilometers? Locale-aware? Reasonably accurate?
+
+        /// <summary>Gets or sets the unique identifier of the lobby.</summary>
+        public ulong Id { get; set; } = 0;
+
+        /// <summary>Gets or sets the type of the lobby, such as Private, or Invisible.</summary>
+        public ELobbyType LobbyType { get; set; } = ELobbyType.Private;
+
+        /// <summary>Gets or sets the total number of players that could join the lobby, but generally
+        /// this value should be 12.</summary>
+        public int MaxMembers { get; set; } = 12;
+
+        /// <summary>Gets or sets the number of players that have joined the lobby.</summary>
+        public int NumPlayers { get; set; } = 0;
+
+        /// <summary>Gets or sets the status of the lobby.</summary>
+        public ELobbyState Status { get; set; } = ELobbyState.Unknown;
+
+
+
+        public int CompareTo(ThunderDomeLobby? other)
+        {
+            if (other is null)
+                return 1;
+            return Id.CompareTo(other.Id);
+        }
+
+        public bool Equals(ThunderDomeLobby? other)
+        {
+            return other != null && Id == other.Id;
+        }
+
+
+        internal static ThunderDomeLobby FromSteamKit(SteamMatchmaking.Lobby lobby)
+        {
+            return new ThunderDomeLobby
+            {
+                AverageElo = lobby.Metadata.TryGetValue("MedianSkill", out var skillValueStr) && int.TryParse(skillValueStr, out int skillValue)
+                    ? skillValue
+                    : 0,
+                Branch = lobby.Metadata.TryGetValue("Branch", out var branchValueStr) && !string.IsNullOrWhiteSpace(branchValueStr)
+                    ? branchValueStr
+                    : "public",
+                Build = lobby.Metadata.TryGetValue("Build", out var buildValueStr) && int.TryParse(buildValueStr, out int buildValue)
+                    ? buildValue
+                    : 0,
+                Distance = lobby.Distance ?? 0,
+                Id = lobby.SteamID.ConvertToUInt64(),
+                LobbyType = lobby.LobbyType,
+                MaxMembers = lobby.MaxMembers,
+                NumPlayers = lobby.NumMembers,
+                Status = lobby.Metadata.TryGetValue("State", out var stateValueStr) && int.TryParse(stateValueStr, out int stateValue)
+                    ? (ELobbyState)stateValue
+                    : ELobbyState.Unknown
+            };
+        }
+    }
+}


### PR DESCRIPTION
**This pull request is not yet intended to be merged!** This is presently here to allow for comments on the github website regarding design decisions and what not.

This all mostly works, but the state tracking is pretty sloppy.

* It utilizes [SteamKit2](https://github.com/SteamRE/SteamKit), which is LGPL-licensed.
  * The only modern dotnet API that readily supports multiple clients
    * Most other attempts resulted in the actual Steam client getting disconnected or shown as playing ns2 during scans. eww.
  * dotnet 6, yay
  * Seems feature-rich even.
  * But poor documentation. sadge
* I think the callback would be better off as an `EventHandler<LobbyCollection>` instead of an `Action<IEnumerable<ThunderDomeLobby>>`, to allow for the callback to modify `LobbyMonitor` state.
  * Such as turning up scanning frequency when a lobby gets > 9 players or something.
* A lot of lobbies that you'll receive are done, or cancelled. The filtering predicate seems essential.
  * Probably need to allow for later modification of the predicate.
  * Same for the action delegate, but an event would make more sense for that.